### PR TITLE
Adds version information to command

### DIFF
--- a/ycrc/.gitignore
+++ b/ycrc/.gitignore
@@ -1,0 +1,3 @@
+ycrc
+ycrc.exe
+*.zip

--- a/ycrc/cmd/root.go
+++ b/ycrc/cmd/root.go
@@ -27,6 +27,8 @@ const (
 )
 
 var (
+	Version  = "DEV"
+
 	debug    bool
 	errored  bool
 	errCount int
@@ -57,6 +59,7 @@ var (
 		Args:  cobra.ExactArgs(1),
 		Short: "YCql Row Count",
 		Long:  "YCql Row Count (ycrc) parallelizes counting the number of rows in a table for YugabyteDB CQL, allowing count(*) on tables that otherwise would fail with query timeouts",
+		Version: Version,
 		Run: func(cmd *cobra.Command, args []string) {
 			rowCount(args[0])
 		},


### PR DESCRIPTION
Additionally adds information to README to set the version.

This is useful to do so that when we send a build out, we can track that
version back to the code used for the build.

Additional add some MD formatting and windows build instructions.