### PR TITLE
fixed query to get hash columns of tables in ysql_table_row_count.py and added CLI config options

### DIFF
--- a/ysql_table_row_count.py
+++ b/ysql_table_row_count.py
@@ -1,0 +1,116 @@
+# pip install psycopg2
+
+import threading
+import time
+import random
+import os
+from functools import partial
+import psycopg2
+
+from multiprocessing.dummy import Pool as ThreadPool
+
+# Which cluster? Which schema? How many sub-tasks? Max parallelism?
+schema_name="public"
+num_tasks_per_table=4096
+num_parallel_tasks=32
+
+cluster = psycopg2.connect("host=127.0.0.1 port=5433 dbname=yugabyte user=yugabyte password=yugabyte")
+session = cluster.cursor()
+
+
+threads = []
+
+def check_partition_row_count(schema_name, table_name, p_columns, cursors, l_bound):
+
+  tid = threading.current_thread().ident
+  if tid not in threads:
+  	threads.append(tid)
+  	
+  index = threads.index(tid)
+  stmt = ("SELECT count(*) as rows FROM {} " +
+          "WHERE yb_hash_code({}) >= %s " +
+          "AND yb_hash_code({}) <= %s").format(
+                                                table_name,
+                                                p_columns,
+                                                p_columns)
+
+  range_size = int((64*1024)/num_tasks_per_table)
+  u_bound = l_bound + range_size - 1
+  cursor = cursors[index]
+  results = cursor.execute(stmt, (int(l_bound), int(u_bound)))
+  assert(cursor.rowcount == 1)
+  row_cnt = cursor.fetchall()[0][0]
+  return row_cnt
+
+def check_table_row_counts(schema_name, table_name):
+    print("Checking row counts for: " + schema_name + "." + table_name);
+    results = session.execute("SELECT a.attname " +
+"FROM   pg_index i " + 
+"JOIN   pg_attribute a ON a.attrelid = i.indrelid " + 
+                     "AND a.attnum = ANY(i.indkey) " + 
+"WHERE  i.indrelid = %s::regclass " +
+"AND    i.indisprimary;",
+                               (table_name,))
+
+    # Add the partition columns to an array sorted by the
+    # position of the column in the primary key.
+    partition_columns = [''] * 256
+    num_partition_columns = 0
+    results = session.fetchall()
+    if len(results) == 0:
+    	return
+    for row in results:
+        partition_columns[num_partition_columns] = row[0]
+        num_partition_columns = num_partition_columns + 1
+    del partition_columns[num_partition_columns:] # remove extra null elements from array
+
+    p_columns = ",".join(partition_columns)
+    print("Partition columns for " + schema_name + "." + table_name + ": (" + p_columns + ")");
+    print("Performing {} checks for {}.{}".format(num_tasks_per_table, schema_name, table_name))
+
+    range_size = int((64*1024)/num_tasks_per_table)
+    l_bounds = []
+    for idx in range(num_tasks_per_table):
+        l_bound = int(idx * range_size)
+        l_bounds.append(l_bound)
+
+
+    pool = ThreadPool(num_parallel_tasks)
+    cursors = []
+    indices = []
+    for i in range(num_parallel_tasks):
+      t_cluster = psycopg2.connect("host=127.0.0.1 port=5433 dbname=yugabyte user=yugabyte password=yugabyte")
+      indices.append(i)
+      cursors.append(t_cluster.cursor())
+
+    t1 = time.time()
+    row_counts = pool.map(partial(check_partition_row_count,
+                                  schema_name,
+                                  table_name,
+                                  p_columns, cursors),
+                          l_bounds)
+    t2 = time.time()
+
+    print("====================")
+    print("Total Time: %s ms" % ((t2 - t1) * 1000))
+    print("====================")
+
+    for i in range(num_parallel_tasks):
+    	cursors[i].close()
+    total_row_cnt = 0
+    for idx in range(len(row_counts)):
+      total_row_cnt = total_row_cnt + row_counts[idx]
+
+    print("Total Row Count for {}.{} = {}".format(schema_name, table_name, total_row_cnt))
+    print("--------------------------------------------------------")
+
+def check_schema_table_row_counts(schema_name):
+    print("Checking table row counts for schema: " + schema_name);
+    print("--------------------------------------------------------")
+    tables = []
+    results = session.execute("select tablename from pg_tables where schemaname = \'" + schema_name + "\'");
+    for row in session.fetchall():
+       check_table_row_counts(schema_name, row[0])
+
+# Main
+check_schema_table_row_counts(schema_name)


### PR DESCRIPTION
The current version of ysql_table_row_count.py falsely detects all clustering keys as hash columns. This PR aims to fix that. We also add CLI options to the script.