### PR TITLE
Update README.md

### DIFF
--- a/yugatool/README.md
+++ b/yugatool/README.md
@@ -4,20 +4,40 @@
 
 ## Building
 
-#### Requirements
+### Requirements
 
 * make
 * direnv (or source .envrc)
 * golang v1.16+
 * protoc v3.14.0
+* golangci-lint (for `make`)
 
-#### Ubuntu 18.04
+### Install Requirements
+#### -- *_Tested on Ubuntu 18.04_* --
+
+#### `apt` packages ####
 
 ```bash
 apt install direnv make
-snap install protobuf
+snap install protobuf --classic
+```
+
+### Install golang
+
+#### Option 1: snap
+```
 snap install golang
 ```
+
+#### Option 2: manual
+
+https://go.dev/doc/install
+
+
+### Install golangci-lint
+
+https://golangci-lint.run/usage/install/
+
 
 #### Build the binary
 


### PR DESCRIPTION
- `snap` installation for `protobuf` requires `--classic` -- added this to the instructions
- added instructions for manual `golang` installation
- `golangci-lint` package is needed, otherwise the `make` command will fail. Added to `Requirements` and added installation instructions