### PR TITLE
yugaware-client: Kubernetes provider namespace registration

### DIFF
--- a/yugaware-client/cmd/provider/create/kubernetesProvider.go
+++ b/yugaware-client/cmd/provider/create/kubernetesProvider.go
@@ -52,6 +52,7 @@ regions:
       - name: us-east1-b
         config:
           storage_class: yugaware
+          kubernetes_namespace: example_namespace
           overrides: |
             nodeSelector:
               cloud.google.com/gke-nodepool: yugabyte-us-east1-b
@@ -248,12 +249,20 @@ func getKubernetesZone(log logr.Logger, info cli.ZoneInfo, kubeconfig []byte) (*
 		Code: info.Name,
 		Name: NewString(info.Name),
 		Config: map[string]string{
-			"STORAGE_CLASS":      info.Config.StorageClass,
 			"OVERRIDES":          info.Config.Overrides,
 			"KUBECONFIG_NAME":    info.Name + "-kubeconfig",
 			"KUBECONFIG_CONTENT": string(kubeconfig),
 		},
 	}
+
+	if info.Config.StorageClass != "" {
+		zone.Config["STORAGE_CLASS"] = info.Config.StorageClass
+	}
+
+	if info.Config.KubernetesNamespace != "" {
+		zone.Config["KUBENAMESPACE"] = info.Config.KubernetesNamespace
+	}
+
 	log.V(1).Info("generated zone", "zone", &zone)
 	return zone, nil
 }

--- a/yugaware-client/entity/cli/cli.go
+++ b/yugaware-client/entity/cli/cli.go
@@ -53,9 +53,10 @@ func (r *YugawareRegistration) MarshalLogObject(enc zapcore.ObjectEncoder) error
 }
 
 type Config struct {
-	StorageClass   string `json:"storage_class,omitempty"`
-	Overrides      string `json:"overrides,omitempty"`
-	KubeconfigPath string `json:"kubeconfig_path,omitempty"`
+	KubernetesNamespace string `json:"kubernetes_namespace,omitempty"`
+	StorageClass        string `json:"storage_class,omitempty"`
+	Overrides           string `json:"overrides,omitempty"`
+	KubeconfigPath      string `json:"kubeconfig_path,omitempty"`
 }
 
 type ZoneInfo struct {


### PR DESCRIPTION
When registering a Kubernetes provider, there is an optional KUBENAMESPACE argument to each zone. When filled in, any universes deployed to that zone with that provider will be deployed to that namespace.