### PR TITLE
[yugaware-client] Initiate, list, and restore backups

### DIFF
--- a/pkg/format/output.go
+++ b/pkg/format/output.go
@@ -45,6 +45,8 @@ func init() {
 			if err != nil {
 				return node, err
 			}
+		} else if node.IsNumeric() {
+			size = int(node.MustNumeric())
 		} else {
 			return node, fmt.Errorf("size_pretty: unknown data type %d", node.Type())
 		}
@@ -105,6 +107,15 @@ func init() {
 
 	})
 
+	ajson.AddFunction("localtime", func(node *ajson.Node) (result *ajson.Node, err error) {
+		if node.IsNumeric() {
+			unixTime := int64(node.MustNumeric())
+			ts := time.Unix(unixTime, 0)
+			return ajson.StringNode("", ts.Format("2006-01-02 15:04:05 MST")), nil
+		}
+		return node, fmt.Errorf("localtime: unknown data type %d", node.Type())
+
+	})
 }
 
 type Output struct {

--- a/yugaware-client/cmd/backup/create.go
+++ b/yugaware-client/cmd/backup/create.go
@@ -1,0 +1,302 @@
+/*
+Copyright © 2021 Yugabyte Support
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/yugabyte/yb-tools/pkg/flag"
+	"github.com/yugabyte/yb-tools/pkg/format"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/client/backups"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/client/customer_configuration"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/models"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/cmdutil"
+)
+
+func CreateCmd(ctx *cmdutil.YWClientContext) *cobra.Command {
+	options := &CreateOptions{}
+	cmd := &cobra.Command{
+		Use:   "create (UNIVERSE_NAME|UNIVERSE_UUID) --storage-config <config>",
+		Short: "Create a backup",
+		Long:  `Create a backup`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ctx.WithCmd(cmd).WithOptions(options).Setup()
+			if err != nil {
+				return err
+			}
+
+			options.UniverseName = args[0]
+
+			err = options.Validate(ctx)
+			if err != nil {
+				return err
+			}
+
+			return create(ctx, options)
+		},
+	}
+	options.AddFlags(cmd)
+
+	return cmd
+}
+
+type CreateOptions struct {
+	UniverseName string // positional arg
+
+	// Common options
+	Type          string        `mapstructure:"type,omitempty"`
+	StorageConfig string        `mapstructure:"storage_config,omitempty"`
+	Retention     time.Duration `mapstructure:"retention,omitempty"`
+	Parallelism   int32         `mapstructure:"parallelism,omitempty"`
+	Wait          bool          `mapstructure:"wait,omitempty"`
+
+	// CQL only options
+	Keyspace string   `mapstructure:"keyspace,omitempty"`
+	Tables   []string `mapstructure:"tables,omitempty"`
+
+	// SQL only options
+	Database string `mapstructure:"database,omitempty"`
+
+	universe *models.UniverseResp
+	storage  *models.CustomerConfigUI
+}
+
+func (o *CreateOptions) AddFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.StringVar(&o.Type, "type", "sql", "Type of backup [sql cql]")
+	flags.StringVar(&o.StorageConfig, "storage-config", "", "The storage type to use for the backup")
+	flags.DurationVar(&o.Retention, "retention", time.Hour*24*7, "backup retention duration")
+	flags.BoolVar(&o.Wait, "wait", false, "Wait for backup completion")
+	flags.Int32Var(&o.Parallelism, "parallelism", 3, "The number of threads for backup/restore (per node)")
+
+	flags.StringArrayVar(&o.Tables, "table", []string{}, "Tables to back up (CQL only)")
+	flags.StringVar(&o.Keyspace, "keyspace", "", "The keyspace to back up (CQL only)")
+
+	flags.StringVar(&o.Database, "database", "", "The database to back up (SQL only)")
+
+	flag.MarkFlagsRequired([]string{"storage-config"}, flags)
+}
+
+func (o *CreateOptions) Validate(ctx *cmdutil.YWClientContext) error {
+	o.Type = strings.ToUpper(o.Type)
+
+	err := o.validateUniverseName(ctx)
+	if err != nil {
+		return err
+	}
+
+	if o.Type == "SQL" {
+		err := o.validateCreateOptionsSQL()
+		if err != nil {
+			return err
+		}
+	} else if o.Type == "CQL" {
+		err := o.validateCreateOptionsCQL()
+		if err != nil {
+			return err
+		}
+	} else {
+		return errors.New(`required flag "type" must be one of [sql cql]`)
+	}
+
+	return o.validateStorageOptions(ctx)
+}
+
+func (o *CreateOptions) validateUniverseName(ctx *cmdutil.YWClientContext) error {
+	validateUniverseNameError := func(err error) error {
+		return fmt.Errorf(`unable to validate universe name "%s": %w`, o.UniverseName, err)
+	}
+
+	if o.UniverseName == "" {
+		return validateUniverseNameError(fmt.Errorf(`required flag "universe-name" is not set`))
+	}
+
+	var err error
+	o.universe, err = ctx.Client.GetUniverseByIdentifier(o.UniverseName)
+	if err != nil {
+		return validateUniverseNameError(err)
+	}
+
+	if o.universe == nil {
+		return validateUniverseNameError(fmt.Errorf("universe does not exist"))
+	}
+
+	return nil
+}
+
+func (o *CreateOptions) validateCreateOptionsSQL() error {
+	if o.Keyspace != "" {
+		return errors.New(`the "keyspace" flag is incompatible with an SQL backup`)
+	}
+
+	if len(o.Tables) != 0 {
+		return errors.New(`table level SQL backups are unsupported`)
+	}
+	return nil
+}
+
+func (o *CreateOptions) validateCreateOptionsCQL() error {
+	if o.Database != "" {
+		return errors.New(`the "database" flag is incompatible with a CQL backup`)
+	}
+
+	if len(o.Tables) != 0 {
+		if o.Keyspace == "" {
+			return errors.New(`a keyspace must be specified when creating a table level backup`)
+		}
+	}
+
+	return nil
+}
+
+func (o *CreateOptions) validateStorageOptions(ctx *cmdutil.YWClientContext) error {
+	var err error
+	o.storage, err = getStorageConfig(ctx, o.StorageConfig)
+
+	return err
+}
+
+func getStorageConfig(ctx *cmdutil.YWClientContext, storageType string) (*models.CustomerConfigUI, error) {
+	configParams := customer_configuration.NewGetListOfCustomerConfigParams().
+		WithCUUID(ctx.Client.CustomerUUID())
+
+	ctx.Log.V(1).Info("getting customer config", "params", configParams)
+	configs, err := ctx.Client.PlatformAPIs.CustomerConfiguration.GetListOfCustomerConfig(configParams, ctx.Client.SwaggerAuth)
+	if err != nil {
+		return nil, err
+	}
+	ctx.Log.V(1).Info("got customer configs", "configs", configs.GetPayload())
+
+	for _, config := range configs.GetPayload() {
+		if *config.Type == models.CustomerConfigTypeSTORAGE {
+			if *config.ConfigName == storageType {
+				return config, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf(`unable to get storage config "%s"`, storageType)
+}
+
+func (o *CreateOptions) getCreateMultiTableBackupParams(ctx *cmdutil.YWClientContext) *backups.CreateMultiTableBackupParams {
+	var nodeCount int32
+	for _, node := range o.universe.UniverseDetails.NodeDetailsSet {
+		if node.IsTserver {
+			nodeCount++
+		}
+	}
+
+	parallelism := nodeCount * o.Parallelism
+
+	var keyspace, backupType string
+	if o.Type == "SQL" {
+		backupType = models.BackupRespBackupTypePGSQLTABLETYPE
+		keyspace = o.Database
+	} else if o.Type == "CQL" {
+		backupType = models.BackupRespBackupTypeYQLTABLETYPE
+		keyspace = o.Keyspace
+	}
+
+	return backups.NewCreateMultiTableBackupParams().
+		WithCUUID(ctx.Client.CustomerUUID()).
+		WithUniUUID(o.universe.UniverseUUID).
+		WithTableBackup(&models.MultiTableBackupRequestParams{
+			ActionType:          models.BackupTableParamsActionTypeCREATE,
+			BackupType:          backupType,
+			Keyspace:            keyspace,
+			Parallelism:         parallelism,
+			StorageConfigUUID:   &o.storage.ConfigUUID,
+			TransactionalBackup: true,
+			TimeBeforeDelete:    int64(o.Retention / time.Millisecond),
+		})
+}
+
+var _ cmdutil.CommandOptions = &CreateOptions{}
+
+func create(ctx *cmdutil.YWClientContext, options *CreateOptions) error {
+	params := options.getCreateMultiTableBackupParams(ctx)
+
+	ctx.Log.V(1).Info("creating backup", "params", params)
+	task, err := ctx.Client.PlatformAPIs.Backups.CreateMultiTableBackup(params, ctx.Client.SwaggerAuth)
+	if err != nil {
+		return err
+	}
+
+	if options.Wait {
+		err = cmdutil.WaitForTaskCompletion(ctx, ctx.Client, task.GetPayload())
+		if err != nil {
+			return err
+		}
+		ctx.Log.V(1).Info("backup complete", "task", task.GetPayload())
+	}
+
+	backupInfo, err := waitForBackupSubmitComplete(ctx, options.universe, task.GetPayload())
+	if err != nil {
+		return err
+	}
+
+	table := &format.Output{
+		OutputMessage: "Created Backup",
+		JSONObject:    backupInfo,
+		OutputType:    ctx.GlobalOptions.Output,
+		TableColumns: []format.Column{
+			{Name: "BACKUP_UUID", JSONPath: "$.backupUUID"},
+			{Name: "TYPE", JSONPath: "$.backupInfo.backupType"},
+			{Name: "KEYSPACE", JSONPath: "$..keyspace"},
+			{Name: "CREATED", Expr: "localtime(@.createTime/1000)"},
+			{Name: "EXPIRES", Expr: "localtime(@.expiry/1000)"},
+			{Name: "ACTION", JSONPath: "$.backupInfo.actionType"},
+			{Name: "STATE", JSONPath: "$.state"},
+		},
+	}
+
+	return table.Print()
+}
+
+func waitForBackupSubmitComplete(ctx *cmdutil.YWClientContext, universe *models.UniverseResp, waitTask *models.YBPTask) ([]*models.Backup, error) {
+	timeout := time.After(15 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			return nil, errors.New("timed out waiting for backup to start")
+		case <-time.After(1 * time.Second):
+			fetchBackupParams := backups.NewFetchBackupsByTaskUUIDParams().
+				WithCUUID(ctx.Client.CustomerUUID()).
+				WithUniUUID(universe.UniverseUUID).
+				WithTUUID(waitTask.TaskUUID)
+
+			backupInfo, err := ctx.Client.PlatformAPIs.Backups.FetchBackupsByTaskUUID(fetchBackupParams, ctx.Client.SwaggerAuth)
+			if err != nil {
+				return nil, err
+			}
+
+			if len(backupInfo.GetPayload()) > 0 {
+				return backupInfo.GetPayload(), nil
+			}
+
+		case <-ctx.Done():
+			ctx.Client.Log.Info("wait cancelled")
+			return nil, nil
+		}
+	}
+}

--- a/yugaware-client/cmd/backup/list.go
+++ b/yugaware-client/cmd/backup/list.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2021 Yugabyte Support
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/spf13/cobra"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/client/universe_management"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/models"
+
+	"github.com/yugabyte/yb-tools/pkg/format"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/client/backups"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/cmdutil"
+)
+
+func ListCmd(ctx *cmdutil.YWClientContext) *cobra.Command {
+	options := &ListOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list [UNIVERSE_NAME|UNIVERSE_IDENTIFIER]...",
+		Short: "List backups for a Yugabyte universe",
+		Long:  `List backups for a Yugabyte universe`,
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, universes []string) error {
+			err := ctx.WithCmd(cmd).WithOptions(options).Setup()
+			if err != nil {
+				return err
+			}
+
+			return list(ctx, universes, options)
+		},
+	}
+	options.AddFlags(cmd)
+
+	return cmd
+}
+
+type ListOptions struct {
+	IncludeRestore bool `mapstructure:"include_restore,omitempty"`
+}
+
+var _ cmdutil.CommandOptions = &ListOptions{}
+
+func (o *ListOptions) AddFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	// Create flags
+	flags.BoolVar(&o.IncludeRestore, "include-restore", false, "include restores in the backup list")
+}
+
+func (o *ListOptions) Validate(_ *cmdutil.YWClientContext) error {
+	return nil
+}
+
+func matchesUniverse(resp *models.UniverseResp, universeIdentifier string) bool {
+	if resp.Name == universeIdentifier {
+		return true
+	}
+
+	if resp.UniverseUUID == strfmt.UUID(universeIdentifier) {
+		return true
+	}
+
+	return false
+}
+
+func shouldListBackups(universe *models.UniverseResp, listOfUniverses []string) bool {
+	hasFilter := len(listOfUniverses) > 0
+
+	if hasFilter {
+		for _, uid := range listOfUniverses {
+			if matchesUniverse(universe, uid) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func list(ctx *cmdutil.YWClientContext, universes []string, options *ListOptions) error {
+	listParams := universe_management.NewListUniversesParams().
+		WithCUUID(ctx.Client.CustomerUUID())
+
+	universesResp, err := ctx.Client.PlatformAPIs.UniverseManagement.ListUniverses(listParams, ctx.Client.SwaggerAuth)
+	if err != nil {
+		return err
+	}
+
+	for _, universe := range universesResp.GetPayload() {
+		if !shouldListBackups(universe, universes) {
+			continue
+		}
+
+		ctx.Log.V(1).Info("fetching backups", "universe", universe)
+		params := backups.NewListOfBackupsParams().
+			WithCUUID(ctx.Client.CustomerUUID()).
+			WithUniUUID(universe.UniverseUUID)
+
+		backups, err := ctx.Client.PlatformAPIs.Backups.ListOfBackups(params, ctx.Client.SwaggerAuth)
+		if err != nil {
+			return err
+		}
+
+		table := &format.Output{
+			OutputMessage: fmt.Sprintf(`Backup list for universe "%s"`, universe.Name),
+			JSONObject:    backups.GetPayload(),
+			OutputType:    ctx.GlobalOptions.Output,
+			TableColumns: []format.Column{
+				{Name: "BACKUP_UUID", JSONPath: "$.backupUUID"},
+				{Name: "TYPE", JSONPath: "$.backupInfo.backupType"},
+				{Name: "KEYSPACE", JSONPath: "$..keyspace"},
+				{Name: "CREATED", Expr: "localtime(@.createTime/1000)"},
+				{Name: "EXPIRES", Expr: "localtime(@.expiry/1000)"},
+				{Name: "SIZE", Expr: "size_pretty(@.backupInfo.backupSizeInBytes)"},
+				{Name: "ACTION", JSONPath: "$.backupInfo.actionType"},
+				{Name: "STATE", JSONPath: "$.state"},
+			},
+		}
+
+		if !options.IncludeRestore {
+			table.Filter = "@.backupInfo.actionType != 'RESTORE'"
+		}
+
+		err = table.Println()
+		if err != nil {
+			ctx.Log.Error(err, "could not list backups for universe", "universe", universe)
+		}
+	}
+
+	return nil
+}

--- a/yugaware-client/cmd/backup/restore.go
+++ b/yugaware-client/cmd/backup/restore.go
@@ -1,0 +1,256 @@
+/*
+Copyright © 2021-2022 Yugabyte Support
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backup
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/spf13/cobra"
+	"github.com/yugabyte/yb-tools/pkg/format"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/client/table_management"
+
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/client/backups"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/client/swagger/models"
+	"github.com/yugabyte/yb-tools/yugaware-client/pkg/cmdutil"
+)
+
+func RestoreCmd(ctx *cmdutil.YWClientContext) *cobra.Command {
+	options := &RestoreOptions{}
+	cmd := &cobra.Command{
+		Use:   "restore BACKUP_UUID",
+		Short: "Restore a backup",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := ctx.WithCmd(cmd).WithOptions(options).Setup()
+			if err != nil {
+				return err
+			}
+
+			options.BackupUUID = args[0]
+
+			err = options.Validate(ctx)
+			if err != nil {
+				return err
+			}
+
+			return restore(ctx, options)
+		},
+	}
+	options.AddFlags(cmd)
+
+	return cmd
+}
+
+type RestoreOptions struct {
+	BackupUUID string // positional arg
+
+	UniverseName string `mapstructure:"universe_name"`
+	Parallelism  int32  `mapstructure:"parallelism"`
+	Wait         bool   `mapstructure:"wait"`
+
+	// TODO: What options should we allow here?
+	//Keyspace      string
+	//ToKeyspace    string
+
+	backup   *models.Backup
+	universe *models.UniverseResp
+}
+
+type keyspaceType struct {
+	TableType string
+	KeySpace  string
+}
+
+func (o *RestoreOptions) AddFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.StringVar(&o.UniverseName, "universe", "", "The universe to restore to")
+	flags.Int32Var(&o.Parallelism, "parallelism", 3, "The number of threads for backup/restore (per node)")
+	flags.BoolVar(&o.Wait, "wait", false, "Wait for the restore to complete")
+
+	// TODO: allow the keyspace to be renamed
+	//flags.StringVar(&o.Keyspace, "keyspace", "", "The keyspace restore")
+	//flags.StringVar(&o.ToKeyspace, "to-keyspace", "", "The keyspace name to use for the new tables")
+}
+
+func (o *RestoreOptions) Validate(ctx *cmdutil.YWClientContext) error {
+	// Step 1: Check to see if the backup exists
+	err := o.validateBackup(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Step 2: Check restore destination to see if it exists
+	err = o.validateUniverse(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Step 3: Validate whether that the keyspace exists at the destination, and refuse to restore if the keyspace exists.
+	return o.validateKeyspaces(ctx)
+
+	// TODO: validate KMS configs
+}
+func (o *RestoreOptions) validateBackup(ctx *cmdutil.YWClientContext) error {
+	params := backups.NewGetBackupV2Params().
+		WithCUUID(ctx.Client.CustomerUUID()).
+		WithBackupUUID(strfmt.UUID(o.BackupUUID))
+
+	backupResponse, err := ctx.Client.PlatformAPIs.Backups.GetBackupV2(params, ctx.Client.SwaggerAuth)
+	o.backup = backupResponse.GetPayload()
+
+	return err
+}
+
+func (o *RestoreOptions) validateUniverse(ctx *cmdutil.YWClientContext) error {
+	var err error
+
+	universe := string(o.backup.UniverseUUID)
+	if o.UniverseName != "" {
+		universe = o.UniverseName
+	}
+
+	o.universe, err = ctx.Client.GetUniverseByIdentifier(universe)
+	if err != nil {
+		return err
+	}
+
+	if o.universe == nil {
+		return fmt.Errorf("universe %s does not exist", universe)
+	}
+
+	return nil
+}
+
+func (o *RestoreOptions) validateKeyspaces(ctx *cmdutil.YWClientContext) error {
+	validateKeyspacesError := func(err error) error {
+		return fmt.Errorf(`cannot restore backup "%s" to universe "%s": %w`, o.BackupUUID, o.universe.Name, err)
+	}
+	params := table_management.NewGetAllTablesParams().
+		WithCUUID(ctx.Client.CustomerUUID()).
+		WithUniUUID(o.universe.UniverseUUID)
+
+	tablesResponse, err := ctx.Client.PlatformAPIs.TableManagement.GetAllTables(params, ctx.Client.SwaggerAuth)
+	if err != nil {
+		return validateKeyspacesError(err)
+	}
+
+	keyspacesInTargetUniverse := map[keyspaceType]bool{}
+	for _, table := range tablesResponse.GetPayload() {
+		keyspacesInTargetUniverse[keyspaceType{
+			KeySpace:  table.KeySpace,
+			TableType: table.TableType,
+		}] = true
+	}
+
+	storage := getBackupStorageInfo(o.backup)
+
+	for _, backupInfo := range storage {
+		if _, ok := keyspacesInTargetUniverse[keyspaceType{
+			TableType: backupInfo.BackupType,
+			KeySpace:  backupInfo.Keyspace,
+		}]; ok {
+			keyspaceLabel := "keyspace"
+			if o.backup.BackupInfo.BackupType == models.BackupTableParamsBackupTypePGSQLTABLETYPE {
+				keyspaceLabel = "database"
+			}
+
+			// TODO: allow the keyspace to be renamed
+			return validateKeyspacesError(fmt.Errorf(`%s "%s" already exists`, keyspaceLabel, backupInfo.Keyspace))
+		}
+	}
+
+	return nil
+}
+
+func (o *RestoreOptions) getRestoreParams(ctx *cmdutil.YWClientContext) *backups.RestoreBackupV2Params {
+	var nodeCount int32
+	for _, node := range o.universe.UniverseDetails.NodeDetailsSet {
+		if node.IsTserver {
+			nodeCount++
+		}
+	}
+
+	parallelism := nodeCount * o.Parallelism
+
+	return backups.NewRestoreBackupV2Params().
+		WithCUUID(ctx.Client.CustomerUUID()).
+		WithBackup(&models.RestoreBackupParams{
+			ActionType:            models.BackupTableParamsActionTypeRESTORE,
+			BackupStorageInfoList: getBackupStorageInfo(o.backup),
+			CustomerUUID:          ctx.Client.CustomerUUID(),
+			StorageConfigUUID:     *o.backup.BackupInfo.StorageConfigUUID,
+			UniverseUUID:          &o.universe.UniverseUUID,
+			Parallelism:           parallelism,
+		})
+}
+func getBackupStorageInfo(backup *models.Backup) []*models.BackupStorageInfo {
+	var storageInfo []*models.BackupStorageInfo
+
+	if backup.BackupInfo.StorageLocation != "" {
+		storageInfo = append(storageInfo, &models.BackupStorageInfo{
+			BackupType:      backup.BackupInfo.BackupType,
+			Keyspace:        backup.BackupInfo.Keyspace,
+			Sse:             backup.BackupInfo.Sse,
+			StorageLocation: backup.BackupInfo.StorageLocation,
+			TableNameList:   backup.BackupInfo.TableNameList, // TODO: filter by table name in CQL type backups?
+		})
+	}
+
+	for _, backupList := range backup.BackupInfo.BackupList {
+		storageInfo = append(storageInfo, &models.BackupStorageInfo{
+			BackupType:      backupList.BackupType,
+			Keyspace:        backupList.Keyspace,
+			Sse:             backupList.Sse,
+			StorageLocation: backupList.StorageLocation,
+			TableNameList:   backupList.TableNameList,
+		})
+	}
+
+	return storageInfo
+}
+
+var _ cmdutil.CommandOptions = &RestoreOptions{}
+
+func restore(ctx *cmdutil.YWClientContext, options *RestoreOptions) error {
+	restoreParams := options.getRestoreParams(ctx)
+
+	task, err := ctx.Client.PlatformAPIs.Backups.RestoreBackupV2(restoreParams, ctx.Client.SwaggerAuth)
+	if err != nil {
+		return err
+	}
+
+	action := "Started"
+	if options.Wait {
+		err = cmdutil.WaitForTaskCompletion(ctx, ctx.Client, task.GetPayload())
+		if err != nil {
+			return err
+		}
+		action = "Completed"
+	}
+
+	table := &format.Output{
+		OutputMessage: fmt.Sprintf("Restore %s", action),
+		JSONObject:    task.GetPayload(),
+		OutputType:    ctx.GlobalOptions.Output,
+		TableColumns: []format.Column{
+			{Name: "TASK_UUID", JSONPath: "$.taskUUID"},
+		},
+	}
+	return table.Print()
+}

--- a/yugaware-client/cmd/root.go
+++ b/yugaware-client/cmd/root.go
@@ -102,6 +102,13 @@ func RootInit() *cobra.Command {
 
 	categories := []CommandCategory{
 		{
+			Name:        "backup",
+			Description: "Interact with Yugabyte backups",
+			Commands: []*cobra.Command{
+				backup.CreateCmd(ctx),
+			},
+		},
+		{
 			Name:        "certificate",
 			Description: "Interact with Yugabyte certificates",
 			Commands: []*cobra.Command{

--- a/yugaware-client/cmd/root.go
+++ b/yugaware-client/cmd/root.go
@@ -20,9 +20,10 @@ import (
 	"os"
 	"strings"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/yugabyte/yb-tools/yugaware-client/cmd/backup"
 	"github.com/yugabyte/yb-tools/yugaware-client/cmd/certificate"
 	"github.com/yugabyte/yb-tools/yugaware-client/cmd/provider"
 	"github.com/yugabyte/yb-tools/yugaware-client/cmd/session"
@@ -106,6 +107,7 @@ func RootInit() *cobra.Command {
 			Description: "Interact with Yugabyte backups",
 			Commands: []*cobra.Command{
 				backup.CreateCmd(ctx),
+				backup.ListCmd(ctx),
 			},
 		},
 		{

--- a/yugaware-client/cmd/root.go
+++ b/yugaware-client/cmd/root.go
@@ -108,6 +108,7 @@ func RootInit() *cobra.Command {
 			Commands: []*cobra.Command{
 				backup.CreateCmd(ctx),
 				backup.ListCmd(ctx),
+				backup.RestoreCmd(ctx),
 			},
 		},
 		{

--- a/yugaware-client/hack/platform.swagger.json
+++ b/yugaware-client/hack/platform.swagger.json
@@ -1133,12 +1133,13 @@
           "type" : "string"
         },
         "completionTime" : {
-          "description" : "Backup completion time",
-          "format" : "date-time",
-          "type" : "string"
+          "description" : "Backup completion time. Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform",
+          "format" : "int64",
+          "type" : "integer"
         },
         "createTime" : {
-          "format" : "date-time",
+          "description": "Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform",
+          "format" : "int64",
           "type" : "integer"
         },
         "customerUUID" : {
@@ -1147,8 +1148,8 @@
           "type" : "string"
         },
         "expiry" : {
-          "description" : "Expiry time (unix timestamp) of the backup",
-          "format" : "date-time",
+          "description" : "Expiry time (unix timestamp) of the backup. Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform",
+          "format" : "int64",
           "type" : "integer"
         },
         "expiryTimeUnit" : {
@@ -1189,8 +1190,9 @@
           "type" : "string"
         },
         "updateTime" : {
-          "format" : "date-time",
-          "type" : "string"
+          "description": "Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform",
+          "format" : "int64",
+          "type" : "integer"
         },
         "version" : {
           "description" : "Version of the backup in a category",
@@ -12911,9 +12913,15 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "If requested schedule backup.",
+            "description" : "If requested schedule backup. Changes from upstream: This API call actually returns a task, not a Schedule",
             "schema" : {
-              "$ref" : "#/definitions/Schedule"
+              "$ref" : "#/definitions/YBPTask"
+            }
+          },
+          "400" : {
+            "description" : "When request fails validations. Changes from upstream: Return code 400 is not in swagger spec",
+            "schema" : {
+              "$ref" : "#/definitions/YBPError"
             }
           }
         },

--- a/yugaware-client/pkg/client/swagger/client/backups/create_multi_table_backup_responses.go
+++ b/yugaware-client/pkg/client/swagger/client/backups/create_multi_table_backup_responses.go
@@ -29,6 +29,12 @@ func (o *CreateMultiTableBackupReader) ReadResponse(response runtime.ClientRespo
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewCreateMultiTableBackupBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -41,22 +47,54 @@ func NewCreateMultiTableBackupOK() *CreateMultiTableBackupOK {
 
 /* CreateMultiTableBackupOK describes a response with status code 200, with default header values.
 
-If requested schedule backup.
+If requested schedule backup. Changes from upstream: This API call actually returns a task, not a Schedule
 */
 type CreateMultiTableBackupOK struct {
-	Payload *models.Schedule
+	Payload *models.YBPTask
 }
 
 func (o *CreateMultiTableBackupOK) Error() string {
 	return fmt.Sprintf("[PUT /api/v1/customers/{cUUID}/universes/{uniUUID}/multi_table_backup][%d] createMultiTableBackupOK  %+v", 200, o.Payload)
 }
-func (o *CreateMultiTableBackupOK) GetPayload() *models.Schedule {
+func (o *CreateMultiTableBackupOK) GetPayload() *models.YBPTask {
 	return o.Payload
 }
 
 func (o *CreateMultiTableBackupOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Schedule)
+	o.Payload = new(models.YBPTask)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewCreateMultiTableBackupBadRequest creates a CreateMultiTableBackupBadRequest with default headers values
+func NewCreateMultiTableBackupBadRequest() *CreateMultiTableBackupBadRequest {
+	return &CreateMultiTableBackupBadRequest{}
+}
+
+/* CreateMultiTableBackupBadRequest describes a response with status code 400, with default header values.
+
+When request fails validations. Changes from upstream: Return code 400 is not in swagger spec
+*/
+type CreateMultiTableBackupBadRequest struct {
+	Payload *models.YBPError
+}
+
+func (o *CreateMultiTableBackupBadRequest) Error() string {
+	return fmt.Sprintf("[PUT /api/v1/customers/{cUUID}/universes/{uniUUID}/multi_table_backup][%d] createMultiTableBackupBadRequest  %+v", 400, o.Payload)
+}
+func (o *CreateMultiTableBackupBadRequest) GetPayload() *models.YBPError {
+	return o.Payload
+}
+
+func (o *CreateMultiTableBackupBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.YBPError)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {

--- a/yugaware-client/pkg/client/swagger/models/backup.go
+++ b/yugaware-client/pkg/client/swagger/models/backup.go
@@ -32,11 +32,10 @@ type Backup struct {
 	// Enum: [YB_BACKUP_SCRIPT YB_CONTROLLER]
 	Category string `json:"category,omitempty"`
 
-	// Backup completion time
-	// Format: date-time
-	CompletionTime strfmt.DateTime `json:"completionTime,omitempty"`
+	// Backup completion time. Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform
+	CompletionTime int64 `json:"completionTime,omitempty"`
 
-	// create time
+	// Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform
 	// Required: true
 	CreateTime *int64 `json:"createTime"`
 
@@ -44,7 +43,7 @@ type Backup struct {
 	// Format: uuid
 	CustomerUUID strfmt.UUID `json:"customerUUID,omitempty"`
 
-	// Expiry time (unix timestamp) of the backup
+	// Expiry time (unix timestamp) of the backup. Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform
 	Expiry int64 `json:"expiry,omitempty"`
 
 	// Time unit for backup expiry time
@@ -77,10 +76,9 @@ type Backup struct {
 	// Format: uuid
 	UniverseUUID strfmt.UUID `json:"universeUUID,omitempty"`
 
-	// update time
+	// Changes from upstream: Format of a date-time field needs to match https://www.rfc-editor.org/rfc/rfc3339#section-5.6, so unix timestamps don't conform
 	// Required: true
-	// Format: date-time
-	UpdateTime *strfmt.DateTime `json:"updateTime"`
+	UpdateTime *int64 `json:"updateTime"`
 
 	// Version of the backup in a category
 	// Enum: [V1 V2]
@@ -100,10 +98,6 @@ func (m *Backup) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateCategory(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateCompletionTime(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -220,18 +214,6 @@ func (m *Backup) validateCategory(formats strfmt.Registry) error {
 
 	// value enum
 	if err := m.validateCategoryEnum("category", "body", m.Category); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *Backup) validateCompletionTime(formats strfmt.Registry) error {
-	if swag.IsZero(m.CompletionTime) { // not required
-		return nil
-	}
-
-	if err := validate.FormatOf("completionTime", "body", "date-time", m.CompletionTime.String(), formats); err != nil {
 		return err
 	}
 
@@ -436,10 +418,6 @@ func (m *Backup) validateUniverseUUID(formats strfmt.Registry) error {
 func (m *Backup) validateUpdateTime(formats strfmt.Registry) error {
 
 	if err := validate.Required("updateTime", "body", m.UpdateTime); err != nil {
-		return err
-	}
-
-	if err := validate.FormatOf("updateTime", "body", "date-time", m.UpdateTime.String(), formats); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds the following sub-commands to `yugaware-client`:

 * `yugaware-client backup create` - Create an SQL or CQL backup in a universe
 * `yugaware-client backup restore` - Restore an SQL or CQL  backup to a universe
 * `yugaware-client backup list` - List backups