### PR TITLE
rotatecert.sh: 0.1.3 - More Subject Key Identifier fixes

### DIFF
--- a/rotatecert.sh
+++ b/rotatecert.sh
@@ -305,7 +305,9 @@ fi
 # Checking the Subject Key Identifier is now a two stage process because a direct pipe to
 # grep produces ambiguous results during a failure. First we read the certificate into a
 # variable, then we grep that variable for the Subject Key Identifier using heredoc syntax.
-root_cert_text=$($OPENSSL x509 -in $ROOT_CERT -noout -text)
+cmd="$OPENSSL x509 -in $ROOT_CERT -noout -text"
+debug "Executing '${cmd}' to read root certificate"
+root_cert_text=$($cmd)
 if [[ $? -ne 0 ]]; then
   fatal 2 "Failed to read certificate '$ROOT_CERT' while checking Subject Key Identifier,"
 fi


### PR DESCRIPTION
Fixes #54 

The primary fix in this commit corrects an issue where the previous fix to Subject Key Identifier did not differentiate between a failure of the openssl command and a failure of the subsequent grep.

This commit splits the check into two separate operations, so if the openssl check fails, that is fatal but if the grep fails, we treat that as a missing Subject Key Identifier. This should address the issue.

Other minor changes:
- Added a header with instructions on how to use the script
- Updated ROOT_CERT_DIR variable to support setting at the CLI with export
- Fixed typo in TODO comment