### PR TITLE
Fix ddl atomicity scripts when TLS is enabled

### DIFF
--- a/ddl_atomicity/ddl_atomicity_check_script_python2.py
+++ b/ddl_atomicity/ddl_atomicity_check_script_python2.py
@@ -33,7 +33,7 @@ html_parser = HTMLParser.HTMLParser()
 if args.master_leader_only:
     print("Checking if the node is the master leader.")
     is_leader = subprocess.check_output(
-        "{} -s http://localhost:9300/metrics | {} yb_node_is_master_leader{{ | {} '{{print $2}}'".format(
+        "{} -skL http://localhost:9300/metrics | {} yb_node_is_master_leader{{ | {} '{{print $2}}'".format(
             args.curl_path,
             args.grep_path,
             args.awk_path
@@ -56,7 +56,7 @@ else:
 # Get table data
 tables_output = json.loads(
     subprocess.check_output(
-        [args.curl_path, "-s", "http://{}:{}/api/v1/tables".format(
+        [args.curl_path, "-skL", "http://{}:{}/api/v1/tables".format(
             master_interface_address,
             args.master_interface_port
         )]
@@ -155,7 +155,7 @@ for dbname, tables in db_tables.items():
             table_schema_json = json.loads(
                 subprocess.check_output([
                     args.curl_path, 
-                    "-s", 
+                    "-skL", 
                     "http://{}:{}/api/v1/table?id={}".format(
                         master_interface_address,
                         args.master_interface_port,

--- a/ddl_atomicity/ddl_atomicity_check_script_python3.py
+++ b/ddl_atomicity/ddl_atomicity_check_script_python3.py
@@ -32,7 +32,7 @@ FNULL = open(os.devnull, 'w')
 if args.master_leader_only:
     print("Checking if the node is the master leader.")
     is_leader = subprocess.check_output(
-        f"{args.curl_path} -s http://localhost:9300/metrics | {args.grep_path} yb_node_is_master_leader{{ | {args.awk_path} '{{print $2}}'", 
+        f"{args.curl_path} -skL http://localhost:9300/metrics | {args.grep_path} yb_node_is_master_leader{{ | {args.awk_path} '{{print $2}}'", 
         shell=True
     ).decode('utf-8').strip()
     if is_leader == "0":
@@ -51,7 +51,7 @@ else:
 # Get table data
 tables_output = json.loads(
     subprocess.check_output(
-        [args.curl_path, "-s", f"http://{master_interface_address}:{args.master_interface_port}/api/v1/tables"]
+        [args.curl_path, "-skL", f"http://{master_interface_address}:{args.master_interface_port}/api/v1/tables"]
     ).decode('utf-8')
 )
 table_data_json = tables_output["user"]
@@ -142,7 +142,7 @@ for dbname, tables in db_tables.items():
             table_schema_json = json.loads(
                 subprocess.check_output([
                     args.curl_path,
-                    "-s",
+                    "-skL",
                     f"http://{master_interface_address}:{args.master_interface_port}/api/v1/table?id={tableid}"
                 ]).decode()
             )


### PR DESCRIPTION
Some curl commands in ddl_atomicity scripts return HTTP code 302 because
they want to redirect the HTTP request to HTTPS in case TLS is enabled.
Use -L to follow the redirect.  Use -k to avoid certificate hassles.