### PR TITLE
Fix PG oid computation in the metadata inconsistency check script

### DIFF
--- a/ddl_atomicity/ddl_atomicity_check_script_python2.py
+++ b/ddl_atomicity/ddl_atomicity_check_script_python2.py
@@ -78,7 +78,7 @@ for table in table_data_json:
     if pg_oid == "" or table["hidden"]:
         continue
     # Extract table oid
-    yb_pg_table_oid = str(int(table["uuid"][-4:], 16))
+    yb_pg_table_oid = str(int(table["uuid"][-8:], 16))
 
     # Add table to the database's list in the dictionary
     if dbname not in db_tables:

--- a/ddl_atomicity/ddl_atomicity_check_script_python3.py
+++ b/ddl_atomicity/ddl_atomicity_check_script_python3.py
@@ -71,7 +71,7 @@ for table in table_data_json:
     if pg_oid == "" or table["hidden"]:
         continue
     # Extract table oid
-    yb_pg_table_oid = str(int(table["uuid"][-4:], 16))
+    yb_pg_table_oid = str(int(table["uuid"][-8:], 16))
 
     # Add table to the database's list in the dictionary
     if dbname not in db_tables:


### PR DESCRIPTION
Compute the PG oid using the last 8 digits of the table ID.