### PR TITLE
Add redundant index detection script

### DIFF
--- a/redundant_index/README.md
+++ b/redundant_index/README.md
@@ -1,0 +1,43 @@
+# Redundant Index Detector
+
+This script identifies redundant (duplicate) indexes in PostgreSQL-compatible databases.
+
+## Overview
+
+When you have multiple indexes on the same table, some may be redundant and safely dropped. For example:
+
+- If you have an index on (a,b,c,d)
+- And another index on (a,b,c) INCLUDE (d)
+- The second index can make the first redundant
+
+## Usage
+
+Run this script on any PostgreSQL-compatible database using psql/ysqlsh (or any other compatible client). The output includes a table of potential redundant indexes along with the existing indexes that make them redundant.
+
+## Example Usage
+
+It’s recommended to turn on extended display mode to see the full query output:
+
+```sql
+yugabyte=# \x
+Expanded display is on.
+yugabyte=# \i redundant_index_detector.sql
+-[ RECORD 1 ]----------------+------------------------------------------------------------------------------------------
+Redundant index name         | idx_expr_def2
+Existing index name          | idx_expr_def1
+Redundant definition         | CREATE INDEX idx_expr_def2 ON test_schema.expr_collations_23 USING lsm (lower(col1) HASH)
+Existing definition          | CREATE INDEX idx_expr_def1 ON test_schema.expr_collations_23 USING lsm (lower(col1) HASH)
+```
+
+In the example above, "idx_expr_def2" could be considered redundant if "idx_expr_def1" covers the same or superset of columns.
+
+## Columns in the Output
+
+The final query in the script returns the following columns:
+
+| Column                 | Description                                      |
+| ---------------------- | ------------------------------------------------ |
+| Redundant index name   | Name of the index that could be safely dropped   |
+| Existing index name    | Name of the index that makes it redundant        |
+| Redundant definition   | Full CREATE INDEX definition of redundant index  |
+| Existing definition    | Full CREATE INDEX definition of existing index   |

--- a/redundant_index/redundant_index_script.sql
+++ b/redundant_index/redundant_index_script.sql
@@ -1,0 +1,300 @@
+/* 
+ * This script identifies redundant (duplicate) indexes.
+ *
+ * For example, if we have an index keyed on (a,b,c,d),
+ * and also an index keyed on (a,b,c) INCLUDE (d),
+ * the second can make the first redundant.
+ */
+
+/*
+ * =========================================
+ *  INDEX ATTRIBUTES
+ * =========================================
+ *
+ * Retrieve per-attribute metadata for each index attribute.
+ */
+WITH ind_att AS (
+    SELECT
+        pg_idx.indrelid,
+        pg_idx.indexrelid,
+        nsp.nspname                                             AS schemaname,
+        tbl.relname                                             AS tablename,
+        idx.relname                                             AS indexname,
+        pg_idx.indexprs,
+        pg_idx.indpred,
+        unkeys.k                                                AS key_position,
+        COALESCE(coll.collname, 'default')                      AS collation_name,
+        pg_get_indexdef(pg_idx.indexrelid, unkeys.k::int, true) AS index_key_def,
+        CASE
+            WHEN (unopts.indopt & 4) = 4 THEN 'HASH'
+            ELSE (CASE WHEN (unopts.indopt & 1) = 1 THEN 'DESC' ELSE 'ASC' END) || 
+                 (CASE WHEN (unopts.indopt & 2) = 2 THEN ' NULLS FIRST' ELSE ' NULLS LAST' END)
+        END                                                     AS options
+    FROM pg_index pg_idx
+         CROSS JOIN LATERAL unnest(pg_idx.indkey) WITH ORDINALITY AS unkeys(indkey, k)
+         LEFT OUTER JOIN LATERAL unnest(pg_idx.indoption) WITH ORDINALITY AS unopts(indopt, pos)
+         ON unopts.pos = unkeys.k
+         JOIN pg_class idx
+           ON idx.oid = pg_idx.indexrelid
+         JOIN pg_namespace nsp
+           ON nsp.oid = idx.relnamespace
+         JOIN pg_class tbl
+           ON tbl.oid = pg_idx.indrelid
+         LEFT JOIN pg_attribute idx_att
+                ON idx_att.attrelid = pg_idx.indexrelid
+               AND idx_att.attnum   = unkeys.k
+               AND idx_att.attnum   > 0
+               AND NOT idx_att.attisdropped
+         LEFT JOIN pg_collation coll
+                ON idx_att.attcollation = coll.oid
+         JOIN pg_am am
+           ON am.oid = idx.relam
+),
+/*
+ * =========================================
+ *  INDEX DETAILS
+ * =========================================
+ *
+ * Retrieve the per-index metadata and aggregate the per-attribute metadata
+ * into arrays for each index. This allows us to easily compare indexes
+ * for redundancy.
+ */
+indexes AS (
+    SELECT
+        i.indrelid,
+        i.indexrelid,
+        n.nspname                          AS schema_name,
+        t.relname                          AS table_name,
+        irel.relname                       AS index_name,
+        i.indisunique                      AS is_unique,
+        i.indnkeyatts,
+        i.indnatts,
+        pg_get_expr(i.indpred, i.indrelid) AS partial_pred,
+        am.amname                          AS access_method,
+        i.nullsnotdistinct                 AS indnullsnotdistinct,
+
+        /*
+         * Make operator class a LEFT JOIN so that included columns
+         * (which have no opclass) do not get dropped.
+         */
+        ARRAY_AGG(ao.index_key_def ORDER BY ao.key_position)      AS columns_expressions,
+        ARRAY_AGG(ao.collation_name ORDER BY ao.key_position)     AS colcollations,
+        ARRAY_AGG(oc.opcname ORDER BY ao.key_position)            AS operator_classes,
+        ARRAY_AGG(ao.options ORDER BY ao.key_position)            AS column_options,
+        ARRAY_AGG(ao.index_key_def ORDER BY ao.key_position)      AS all_columns,
+
+        /* Key columns only (first indnkeyatts) */
+        (ARRAY_AGG(ao.index_key_def ORDER BY ao.key_position))[1:i.indnkeyatts]
+            AS key_columns,
+
+        /* Included columns only (everything after the key) */
+        CASE
+            WHEN i.indnkeyatts < i.indnatts
+            THEN (ARRAY_AGG(ao.index_key_def ORDER BY ao.key_position))[
+                     (i.indnkeyatts+1):
+                 ]
+            ELSE ARRAY[]::text[]
+        END
+            AS included_columns
+
+    FROM ind_att ao
+    JOIN (SELECT *, (row_to_json(pg_index)->>'indnullsnotdistinct')::boolean AS nullsnotdistinct FROM pg_index) i
+      ON i.indexrelid = ao.indexrelid
+    JOIN pg_class irel
+      ON irel.oid = i.indexrelid
+    JOIN pg_namespace n
+      ON n.oid = irel.relnamespace
+    JOIN pg_class t
+      ON t.oid = i.indrelid
+    JOIN pg_am am
+      ON am.oid = irel.relam
+
+    LEFT OUTER JOIN LATERAL unnest(i.indclass) WITH ORDINALITY AS opcls(opc, pos)
+      ON ao.key_position = pos
+    LEFT OUTER JOIN pg_opclass oc
+      ON oc.oid = opcls.opc
+
+    /* Filter out system schemas at this point */
+    WHERE ao.schemaname NOT IN ('pg_catalog', 'information_schema')
+
+    GROUP BY
+        i.indrelid,
+        i.indexrelid,
+        n.nspname,
+        t.relname,
+        irel.relname,
+        i.indisunique,
+        i.indnkeyatts,
+        i.indpred,
+        am.amname,
+        i.indnatts,
+        i.nullsnotdistinct
+),
+indexes_no_constraints AS (
+    SELECT idx.*
+      FROM indexes idx
+      LEFT JOIN pg_constraint c
+             ON c.conindid = (
+                SELECT cc.oid
+                  FROM pg_class cc
+                 WHERE cc.relname      = idx.index_name
+                   AND cc.relnamespace = (
+                       SELECT ns.oid
+                         FROM pg_namespace ns
+                        WHERE ns.nspname = idx.schema_name
+                   )
+             )
+     WHERE c.conindid IS NULL
+)
+
+/*
+ * =========================================
+ *  REDUNDANCY LOGIC
+ * =========================================
+ *
+ * This final query performs the redundancy check.
+ * We join together two versions of the index metadata
+ * CTE, looking for pairs of indexes where one (the "redundant")
+ * is redundant with respect to the other (the "existing").
+ *
+ */
+SELECT DISTINCT ON (redundant.schema_name, redundant.table_name, redundant.index_name)
+    redundant.index_name                  AS "Redundant index name",
+    existing.index_name                   AS "Existing index name", 
+    pg_get_indexdef(redundant.indexrelid) AS "Redundant definition",
+    pg_get_indexdef(existing.indexrelid)  AS "Existing definition",
+    redundant.indnullsnotdistinct         AS "Redundant NULLS NOT DISTINCT",
+    existing.indnullsnotdistinct         AS "Existing NULLS NOT DISTINCT"
+
+/*
+ * Only consider non-constraint indexes for dropping.
+ * However, we still consider constraint indexes for
+ * determining if a non-constraint index is redundant.
+ */
+FROM indexes_no_constraints redundant
+JOIN indexes existing
+  ON redundant.schema_name   = existing.schema_name
+ AND redundant.table_name    = existing.table_name
+ AND redundant.index_name   <> existing.index_name
+ AND redundant.access_method = existing.access_method
+
+ /*
+  * Redundant must be same length or "smaller" in actual keyed columns 
+  * to be overshadowed by the existing. 
+  */
+ AND redundant.indnkeyatts <= existing.indnkeyatts
+
+ /*
+  * Partial index logic: consider a partial index overshadowed if there's a 
+  * full (no predicate) index on the same columns, or if the partial 
+  * predicates match exactly.
+  */
+ AND (
+    existing.partial_pred IS NULL
+    OR redundant.partial_pred = existing.partial_pred
+ )
+
+ /*
+  * Operator classes, collations, etc. must match for the key columns.
+  * The column_options array is defined in the ind_att CTE and contains
+  * HASH/ASC/DESC and NULLS FIRST/NULLS LAST information.
+  */
+ AND existing.operator_classes[1 : redundant.indnkeyatts]
+     = redundant.operator_classes[1 : redundant.indnkeyatts]
+ AND existing.colcollations[1 : redundant.indnkeyatts]
+     = redundant.colcollations[1 : redundant.indnkeyatts]
+
+ /*
+  * Column options must match for the key columns.
+  * ASC/DESC are stronger guarantees than HASH, so allow
+  * for ASC/DESC to replace HASH.
+  */
+ AND (
+  SELECT bool_and(
+    redundant.column_options[i] = existing.column_options[i]
+    OR (
+      redundant.column_options[i] = 'HASH'
+      AND existing.column_options[i] <> 'HASH'
+    )
+  )
+  FROM generate_series(1, redundant.indnkeyatts) AS g(i)
+  )
+
+ /*
+  * ============================
+  *  KEY vs. INCLUDED LOGIC
+  * ============================
+  *
+  * Basic idea:
+  *  - If Redundant's key columns are a prefix of existing's key columns,
+  *    and all of redundant's included columns appear in existing’s remaining columns,
+  *    then redundant is redundant.
+  *
+  *  - Or if they are exactly the same key columns, and existing includes at least
+  *    the same included columns, redundant is also redundant.
+  */
+ AND (
+    -- Redundant's key columns are prefix of existing's key columns
+    -- this includes the case where they are the same
+    existing.key_columns[1 : redundant.indnkeyatts] 
+      = redundant.key_columns
+    
+    
+    /*
+     * Redundant's included columns are contained in the remainder of existing's columns.
+     * The remainder is defined as the included columns of the existing, plus any
+     * key columns that are not in the redundant's key columns.
+     */
+    AND redundant.included_columns <@ existing.all_columns[(redundant.indnkeyatts+1):]
+
+    /*
+     * One of the following must be true:
+     *  - Both indexes are unique
+     *  - Both indexes are not unique
+     *  - The redundant index is not unique, and the existing is unique
+     */
+    AND (
+      (
+        redundant.is_unique AND existing.is_unique
+
+        /*
+         * If both indexes are unique, their key columns must be the same.
+         *
+         * For example, if we have UNIQUE (a, b) and UNIQUE (a, b, c),
+         * we can't drop UNIQUE (a, b) because it enforces a stronger
+         * constraint than UNIQUE (a, b, c), and we can't drop UNIQUE (a, b, c)
+         * because it has more key columns.
+         */
+        AND redundant.key_columns = existing.key_columns
+
+        /*
+         * NULLS NOT DISTINCT is a stronger guarantee than NULLS DISTINCT (default).
+         * If the redundant index has NULLS NOT DISTINCT, the existing must also have NULLS NOT DISTINCT.
+         */
+        AND (NOT redundant.indnullsnotdistinct OR existing.indnullsnotdistinct)
+      )
+      OR (
+        NOT redundant.is_unique AND NOT existing.is_unique
+      )
+      OR (
+        NOT redundant.is_unique AND existing.is_unique
+      )
+    )
+ )
+
+ /*
+  * If both indexes are exactly the same, break ties deterministically.
+  * We do this by picking the larger name to drop.
+  */
+ AND NOT (
+  redundant.key_columns = existing.key_columns
+  AND redundant.included_columns = existing.included_columns
+  AND redundant.is_unique = existing.is_unique
+  AND redundant.indnullsnotdistinct = existing.indnullsnotdistinct
+  AND redundant.index_name < existing.index_name
+ )
+ORDER BY
+    redundant.schema_name,
+    redundant.table_name,
+    redundant.index_name,
+    existing.index_name;


### PR DESCRIPTION
Adds a script that can be run on any YSQL cluster to detect redundant indexes. This script returns a list of indexes that can be dropped along with the indexes that make them redundant.